### PR TITLE
Add missing instructions

### DIFF
--- a/src/main/com/unsafepointer/chihaya/emulator.clj
+++ b/src/main/com/unsafepointer/chihaya/emulator.clj
@@ -79,6 +79,7 @@
       [\8 _ _\E] (instructions/shl-Vx state Vx)
       [\9 _ _\0] (instructions/sne-Vx-Vy state Vx Vy)
       [\A _ _ _] (instructions/ld-I-addr state nnn)
+      [\C _ _ _] (instructions/rnd-Vx-kk state Vx kk)
       [\D _ _ _] (instructions/drw-Vx-Vy-nibble state Vx Vy nibble)
       [\E _\9\E] (instructions/skp-Vx state Vx)
       [\E _\A\1] (instructions/sknp-Vx state Vx)

--- a/src/main/com/unsafepointer/chihaya/emulator.clj
+++ b/src/main/com/unsafepointer/chihaya/emulator.clj
@@ -86,6 +86,7 @@
       [\F _\1\5] (instructions/ld-DT-Vx state Vx)
       [\F _\1\8] (instructions/ld-ST-Vx state Vx)
       [\F _\1\E] (instructions/add-I-Vx state Vx)
+      [\F _\2\9] (instructions/ld-F-Vx state Vx)
       [\F _\3\3] (instructions/ld-B-Vx state Vx)
       [\F _\5\5] (instructions/ld-I-Vx state Vx)
       [\F _\6\5] (instructions/ld-Vx-I state Vx)

--- a/src/main/com/unsafepointer/chihaya/instructions.clj
+++ b/src/main/com/unsafepointer/chihaya/instructions.clj
@@ -339,3 +339,13 @@
         Vx-value (nth registers Vx)
         address (* 5 Vx-value)]
     (swap! state assoc :address-register address)))
+
+(defn rnd-Vx-kk
+  "Cxkk - RND Vx, byte
+  Set Vx = random byte AND kk"
+  [state Vx kk]
+  (let [random (rand-int 0xFF)
+        value (bit-and random kk)
+        registers (:registers @state)
+        updated-registers (assoc registers Vx value)]
+    (swap! state assoc :registers updated-registers)))

--- a/src/main/com/unsafepointer/chihaya/instructions.clj
+++ b/src/main/com/unsafepointer/chihaya/instructions.clj
@@ -330,3 +330,12 @@
   (let [registers (:registers @state)
         Vx-value (nth registers Vx)]
     (swap! state assoc :sound-timer-register Vx-value)))
+
+(defn ld-F-Vx
+  "Fx29 - LD F, Vx
+  Set I = location of sprite for digit Vx."
+  [state Vx]
+  (let [registers (:registers @state)
+        Vx-value (nth registers Vx)
+        address (* 5 Vx-value)]
+    (swap! state assoc :address-register address)))


### PR DESCRIPTION
Pong (SHA1: a60611339661e3ab2d8af024ad1da5880a6f8665) is playable now:

![output2](https://user-images.githubusercontent.com/346590/76153086-84bda180-60c7-11ea-9c73-d8703da5f4d3.gif)
